### PR TITLE
Sort libs paths, enable pear/pecl, add --enable-gd

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Install packages for Ubuntu
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt install autoconf bison build-essential curl gettext libcurl4-openssl-dev libedit-dev libicu-dev libjpeg-dev libmysqlclient-dev libonig-dev libpng-dev libpq-dev libreadline-dev libsqlite3-dev libssl-dev libxml2-dev libzip-dev openssl pkg-config re2c zlib1g-dev
+        run: sudo apt update && sudo apt install autoconf bison build-essential curl gettext libcurl4-openssl-dev libedit-dev libicu-dev libjpeg-dev libmysqlclient-dev libonig-dev libpng-dev libpq-dev libreadline-dev libsqlite3-dev libssl-dev libxml2-dev libzip-dev openssl pkg-config re2c zlib1g-dev
 
       - name: Install packages for macOS
         if: matrix.os == 'macos-latest'

--- a/bin/install
+++ b/bin/install
@@ -68,7 +68,43 @@ install_composer() {
 construct_configure_options() {
   local install_path=$1
 
-  global_config="--prefix=$install_path --sysconfdir=$install_path --with-config-file-path=$install_path --with-config-file-scan-dir=$install_path/conf.d --enable-bcmath --enable-calendar --enable-dba --enable-exif --enable-ftp --enable-gd-native-ttf --enable-intl --enable-mbregex --enable-mbstring --enable-shmop --enable-soap --enable-sockets --enable-sysvmsg --enable-sysvsem --enable-sysvshm --enable-wddx --enable-zip --with-zip --with-gd --with-mhash --with-xmlrpc --with-curl --without-gmp --without-snmp --with-mysql=mysqlnd --with-mysqli=mysqlnd --with-pdo-mysql=mysqlnd --enable-mysqlnd --enable-pcntl --enable-fpm --with-fpm-user=www-data --with-fpm-group=www-data"
+  global_config="--prefix=$install_path \
+	  --sysconfdir=$install_path \
+	  --with-config-file-path=$install_path \
+	  --with-config-file-scan-dir=$install_path/conf.d \
+	  --enable-bcmath \
+	  --enable-calendar \
+	  --enable-dba \
+	  --enable-exif \
+	  --enable-ftp \
+	  --enable-gd-native-ttf \
+	  --enable-intl \
+	  --enable-mbregex \
+	  --enable-mbstring \
+	  --enable-shmop \
+	  --enable-soap \
+	  --enable-sockets \
+	  --enable-sysvmsg \
+	  --enable-sysvsem \
+	  --enable-sysvshm \
+	  --enable-wddx \
+	  --enable-zip \
+	  --with-zip \
+	  --with-gd \
+	  --enable-gd \
+	  --with-mhash \
+	  --with-xmlrpc \
+	  --with-curl \
+	  --without-gmp \
+	  --without-snmp \
+	  --with-mysql=mysqlnd \
+	  --with-mysqli=mysqlnd \
+	  --with-pdo-mysql=mysqlnd \
+	  --enable-mysqlnd \
+	  --enable-pcntl \
+	  --enable-fpm \
+	  --with-fpm-user=www-data \
+	  --with-fpm-group=www-data"
 
   if [ "$PHP_CONFIGURE_OPTIONS" = "" ]; then
     local configure_options="$(os_based_configure_options) $global_config"
@@ -78,6 +114,8 @@ construct_configure_options() {
 
   if [ "${PHP_WITHOUT_PEAR:-no}" != "no" ]; then
     configure_options="$configure_options --without-pear"
+  else
+    configure_options="$configure_options --with-pear"
   fi
 
   echo "$configure_options"
@@ -204,20 +242,20 @@ os_based_configure_options() {
       configure_options="$configure_options --without-iconv"
     fi
   else
-    local jpeg_path=$(locate libjpeg.so | head -n 1)
-    local libpng_path=$(locate libpng.so | head -n 1)
+    local jpeg_path=$(locate libjpeg.so | awk '{ print length(), $0 | "sort -n" }' | cut -d" " -f2- | head -n 1)
+    local libpng_path=$(locate libpng.so | awk '{ print length(), $0 | "sort -n" }' | cut -d" " -f2- | head -n 1)
     configure_options="--with-openssl --with-curl --with-zlib --with-readline --with-gettext"
 
     if [ "$jpeg_path" = "" ]; then
       export ASDF_PKG_MISSING="$ASDF_PKG_MISSING jpeg"
     else
-      configure_options="$configure_options --with-jpeg-dir=$jpeg_path"
+      configure_options="$configure_options --with-jpeg-dir=$jpeg_path --with-jpeg"
     fi
 
     if [ "$libpng_path" = "" ]; then
       export ASDF_PKG_MISSING="$ASDF_PKG_MISSING libpng"
     else
-      configure_options="$configure_options --with-png-dir=$libpng_path"
+      configure_options="$configure_options --with-png-dir=$libpng_path --with-png"
     fi
   fi
 


### PR DESCRIPTION
1. Sort output of locate by length, hoping to get system libs instead of libs bundled with random applications (in my case libjpeg.so, libpng.so bundled in intellij)
2. Enable pear if pear wasn't explicitly disabled (default has been changed to not install it (https://github.com/php/php-src/pull/3781))
3. Add --enable-gd as that's the new flag for --with-gd (https://www.php.net/manual/en/migration74.other-changes.php#migration74.other-changes.pkg-config)