### PR TITLE
Automatically set PKG_CONFIG_PATH and PATH on MacOS

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -33,14 +33,6 @@ jobs:
       - name: Install packages
         run: brew install autoconf automake bison freetype gd gettext icu4c krb5 libedit libiconv libjpeg libpng libxml2 libzip pkg-config re2c zlib
 
-      # export PKG_CONFIG_PATH="$(brew --prefix icu4c)/lib/pkgconfig:$(brew --prefix krb5)/lib/pkgconfig:$(brew --prefix libedit)/lib/pkgconfig:$(brew --prefix libxml2)/lib/pkgconfig:$(brew --prefix openssl)/lib/pkgconfig"
-      - name: Add PKG_CONFIG_PATH environment variable
-        run: echo "PKG_CONFIG_PATH=$(brew --prefix icu4c)/lib/pkgconfig:$(brew --prefix krb5)/lib/pkgconfig:$(brew --prefix libedit)/lib/pkgconfig:$(brew --prefix libxml2)/lib/pkgconfig:$(brew --prefix openssl)/lib/pkgconfig" >>"$GITHUB_ENV"
-
-      # export PATH="$(brew --prefix bison)/bin:$PATH"
-      - name: Add bison path
-        run: echo "$(brew --prefix bison)/bin" >>"$GITHUB_PATH"
-
       - name: asdf_plugin_test
         uses: asdf-vm/actions/plugin-test@v1
         with:

--- a/bin/install
+++ b/bin/install
@@ -20,7 +20,6 @@ install_php() {
   download_source $install_type $version $source_path
 
   local operating_system=$(uname -a)
-  local configure_options=""
 
   if [[ $operating_system =~ "Darwin" ]]; then
     exit_if_homebrew_not_installed

--- a/bin/install
+++ b/bin/install
@@ -19,6 +19,62 @@ install_php() {
 
   download_source $install_type $version $source_path
 
+  local operating_system=$(uname -a)
+  local configure_options=""
+
+  if [[ $operating_system =~ "Darwin" ]]; then
+    exit_if_homebrew_not_installed
+
+    local bison_path=$(homebrew_package_path bison)
+    local icu4c_path=$(homebrew_package_path icu4c)
+    local krb5_path=$(homebrew_package_path krb5)
+    local libedit_path=$(homebrew_package_path libedit)
+    local libxml2_path=$(homebrew_package_path libxml2)
+    local openssl_path=$(homebrew_package_path openssl)
+
+    if [ -n "${bison_path}" ]; then
+      export "PATH=${bison_path}/bin:${PATH}"
+    else
+      echo "bison not installed" 1>&2
+      return 1
+    fi
+
+    if [ -n "${icu4c_path}" ]; then
+      export "PKG_CONFIG_PATH=${icu4c_path}/lib/pkgconfig:${PKG_CONFIG_PATH}"
+    else
+      echo "icu4c not installed" 1>&2
+      return 1
+    fi
+
+    if [ -n "${krb5_path}" ]; then
+      export "PKG_CONFIG_PATH=${krb5_path}/lib/pkgconfig:${PKG_CONFIG_PATH}"
+    else
+      echo "krb5 not installed" 1>&2
+      return 1
+    fi
+
+    if [ -n "${libedit_path}" ]; then
+      export "PKG_CONFIG_PATH=${libedit_path}/lib/pkgconfig:${PKG_CONFIG_PATH}"
+    else
+      echo "libedit not installed" 1>&2
+      return 1
+    fi
+
+    if [ -n "${libxml2_path}" ]; then
+      export "PKG_CONFIG_PATH=${libxml2_path}/lib/pkgconfig:${PKG_CONFIG_PATH}"
+    else
+      echo "libxml2 not installed" 1>&2
+      return 1
+    fi
+
+    if [ -n "${openssl_path}" ]; then
+      export "PKG_CONFIG_PATH=${openssl_path}/lib/pkgconfig:${PKG_CONFIG_PATH}"
+    else
+      echo "openssl not installed" 1>&2
+      return 1
+    fi
+  fi
+
   # Running this in a subshell because we don't to disturb the current
   # working directory.
   (
@@ -139,7 +195,7 @@ os_based_configure_options() {
     exit_if_homebrew_not_installed
 
     local freetype_path=$(homebrew_package_path freetype)
-    local bison27_path=$(homebrew_package_path bison@2.7)
+    local bison_path=$(homebrew_package_path bison)
     local gettext_path=$(homebrew_package_path gettext)
     local icu4c_path=$(homebrew_package_path icu4c)
     local webp_path=$(homebrew_package_path webp)
@@ -160,8 +216,8 @@ os_based_configure_options() {
       configure_options="--with-freetype-dir=$freetype_path"
     fi
 
-    if [ "$bison27_path" = "" ]; then
-      export ASDF_PKG_MISSING="$ASDF_PKG_MISSING bison27"
+    if [ "$bison_path" = "" ]; then
+      export ASDF_PKG_MISSING="$ASDF_PKG_MISSING bison"
     fi
 
     if [ "$gettext_path" = "" ]; then

--- a/bin/install
+++ b/bin/install
@@ -17,8 +17,6 @@ install_php() {
   local configure_options="$(construct_configure_options $install_path)"
   local make_flags="-j$ASDF_CONCURRENCY"
 
-  download_source $install_type $version $source_path
-
   local operating_system=$(uname -a)
 
   if [[ $operating_system =~ "Darwin" ]]; then
@@ -73,6 +71,8 @@ install_php() {
       return 1
     fi
   fi
+
+  download_source $install_type $version $source_path
 
   # Running this in a subshell because we don't to disturb the current
   # working directory.


### PR DESCRIPTION
`asdf-php` assumes brew so it's seems wasteful to require users to exports these variables for `asdf install` to work correctly. This PR takes the example from GitHub Actions and does it automatically.