### PR TITLE
feat: make pgsql configurable

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -158,7 +158,7 @@ construct_configure_options() {
     configure_options="$configure_options --with-pear"
   fi
 
-  if [ "${PHP_WITHOUT_PGSQL:-no}" != "no" ]; then
+  if [ "${PHP_WITHOUT_PDO_PGSQL:-no}" != "no" ]; then
     configure_options="$configure_options"
   else
     configure_options="$configure_options --with-pdo-pgsql"

--- a/bin/install
+++ b/bin/install
@@ -135,7 +135,6 @@ construct_configure_options() {
     --with-mysql=mysqlnd \
     --with-mysqli=mysqlnd \
     --with-pdo-mysql=mysqlnd \
-    --with-pdo-pgsql \
     --with-xmlrpc \
     --with-zip \
     --with-zlib \
@@ -157,6 +156,12 @@ construct_configure_options() {
     configure_options="$configure_options --without-pear"
   else
     configure_options="$configure_options --with-pear"
+  fi
+
+  if [ "${PHP_WITHOUT_PGSQL:-no}" != "no" ]; then
+    configure_options="$configure_options"
+  else
+    configure_options="$configure_options --with-pdo-pgsql"
   fi
 
   echo "$configure_options"


### PR DESCRIPTION
This makes the `--with-pdo-pgsql` configurable and allows users to install PHP without requiring Postgres to be installed in a specific way on OSX.

`PHP_WITHOUT_PSQL=yes asdf install php`