### PR TITLE
Additional extensions and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,54 @@ for us to support them.
 ## Installation
 
 ```bash
-asdf plugin-add php https://github.com/asdf-community/asdf-php.git
+asdf plugin-add php
 ```
+
+Since this plugin compiles PHP from source, you'll want to ensure all other required packages are installed.
+After you've installed additional system packages, install a specific PHP version:
+
+```bash
+asdf install php 7.4.16
+```
+
+You can test to ensure the installation was successful:
+
+```bash
+asdf reshim
+php --version
+```
+
+Composer is installed globally alongside PHP by default. If your application requires additional php extensions, you may need to install them via `pecl`. For example:
+
+```bash
+pecl install redis
+pecl install imagick
+
+echo "extension=redis.so
+extension=imagick.so" > $(asdf where php)/conf.d/php.ini
+```
+
+#### MacOS
+
+To install PHP on MacOS, you'll need a set of packages installed via homebrew:
+
+```bash
+brew install bison bzip2 freetype gettext libiconv icu4c jpeg libedit libpng libxml2 libzip openssl readline webp zlib
+```
+
+You may want to run the above command with `upgrade` instead of `install` to ensure the latest version of all required packages is installed.
+
+There's also a set of optional packages which enable additional extensions to be enabled:
+
+```
+brew install gmp libsodium imagemagick
+```
+
+Note that the supported extension are not exhaustive, so you may need edit the `bin/install` script to support additional extension. Feel free to submit a PR for any missing extensions.
 
 #### Note: PHP-PEAR
 
-PHP PEAR is down without ETA for when the server will be back. To install PHP
-without PEAR you can specify a `PHP_WITHOUT_PEAR` variable with any value
+If PHP PEAR is down you can install PHP without PEAR. Specify `PHP_WITHOUT_PEAR` variable with any value
 (except no), eg:
 
 ```bash
@@ -41,9 +82,7 @@ install & manage versions.
 
 ## Global Composer Dependencies
 
-After installing a global composer package you will need to run `asdf reshim`.
-
-### Example
+Composer is installed globally by default. To use it, you'll need to reshim:
 
 ```shell
 composer global require friendsofphp/php-cs-fixer

--- a/README.md
+++ b/README.md
@@ -24,18 +24,7 @@ for us to support them.
 asdf plugin-add php https://github.com/asdf-community/asdf-php.git
 ```
 
-Since this plugin compiles PHP from source, you'll want to ensure all other required packages are installed.
-After you've installed additional system packages, install a specific PHP version:
-
-```bash
-asdf install php latest
-```
-
-You can test to ensure the installation was successful:
-
-```bash
-php --version
-```
+## Note
 
 Composer is installed globally alongside PHP by default. If your application requires additional php extensions, you may need to install them via `pecl`. For example:
 
@@ -49,7 +38,7 @@ extension=imagick.so" > $(asdf where php)/conf.d/php.ini
 
 #### macOS
 
-To install PHP on MacOS, you'll need a set of packages [installed via homebrew](https://github.com/asdf-community/asdf-php/blob/248e9c6e2a7824510788f05e8cee848a62200b65/.github/workflows/workflow.yml#L52).
+To install PHP on macOS, you'll need a set of packages [installed via homebrew](https://github.com/asdf-community/asdf-php/blob/248e9c6e2a7824510788f05e8cee848a62200b65/.github/workflows/workflow.yml#L52).
 
 You may want to install these packages using `upgrade` instead of `install` to ensure the latest version of all required packages is installed.
 
@@ -61,7 +50,7 @@ brew install gmp libsodium imagemagick
 
 Note that the supported extension are not exhaustive, so you may need edit the `bin/install` script to support additional extension. Feel free to submit a PR for any missing extensions.
 
-#### Note: PHP-PEAR
+#### PHP-PEAR
 
 If PHP PEAR is down you can install PHP without PEAR. Specify `PHP_WITHOUT_PEAR` variable with any value
 (except no), eg:

--- a/README.md
+++ b/README.md
@@ -21,20 +21,19 @@ for us to support them.
 ## Installation
 
 ```bash
-asdf plugin-add php
+asdf plugin-add php https://github.com/asdf-community/asdf-php.git
 ```
 
 Since this plugin compiles PHP from source, you'll want to ensure all other required packages are installed.
 After you've installed additional system packages, install a specific PHP version:
 
 ```bash
-asdf install php 7.4.16
+asdf install php latest
 ```
 
 You can test to ensure the installation was successful:
 
 ```bash
-asdf reshim
 php --version
 ```
 
@@ -48,7 +47,7 @@ echo "extension=redis.so
 extension=imagick.so" > $(asdf where php)/conf.d/php.ini
 ```
 
-#### MacOS
+#### macOS
 
 To install PHP on MacOS, you'll need a set of packages installed via homebrew:
 

--- a/README.md
+++ b/README.md
@@ -49,13 +49,9 @@ extension=imagick.so" > $(asdf where php)/conf.d/php.ini
 
 #### macOS
 
-To install PHP on MacOS, you'll need a set of packages installed via homebrew:
+To install PHP on MacOS, you'll need a set of packages [installed via homebrew](https://github.com/asdf-community/asdf-php/blob/248e9c6e2a7824510788f05e8cee848a62200b65/.github/workflows/workflow.yml#L52).
 
-```bash
-brew install bison bzip2 freetype gettext libiconv icu4c jpeg libedit libpng libxml2 libzip openssl readline webp zlib
-```
-
-You may want to run the above command with `upgrade` instead of `install` to ensure the latest version of all required packages is installed.
+You may want to install these packages using `upgrade` instead of `install` to ensure the latest version of all required packages is installed.
 
 There's also a set of optional packages which enable additional extensions to be enabled:
 

--- a/bin/install
+++ b/bin/install
@@ -96,7 +96,7 @@ install_php() {
 
   # it's not obvious where php.ini should be placed, let us make it easy for the user
   mkdir -p $install_path/conf.d/
-  echo "# add system-wide php configuration options here" > $install_path/conf.d/php.ini
+  echo "# add system-wide php configuration options here" >$install_path/conf.d/php.ini
 }
 
 install_composer() {

--- a/bin/install
+++ b/bin/install
@@ -389,5 +389,5 @@ get_php_version() {
   fi
 }
 
-install_php $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH
-install_composer ${ASDF_INSTALL_PATH}
+install_php "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"
+install_composer "$ASDF_INSTALL_PATH"

--- a/bin/install
+++ b/bin/install
@@ -95,7 +95,7 @@ install_php() {
   )
 
   # it's not obvious where php.ini should be placed, let us make it easy for the user
-  mkdir $install_path/conf.d/
+  mkdir -p $install_path/conf.d/
   echo "# add system-wide php configuration options here" > $install_path/conf.d/php.ini
 }
 

--- a/bin/install
+++ b/bin/install
@@ -13,6 +13,7 @@ install_php() {
     local tmp_download_dir=${TMPDIR%/}
   fi
 
+  echo "Determining configuration options..."
   local source_path=$(get_download_file_path $install_type $version $tmp_download_dir)
   local configure_options="$(construct_configure_options $install_path)"
   local make_flags="-j$ASDF_CONCURRENCY"
@@ -66,11 +67,13 @@ install_php() {
     fi
   fi
 
+  echo "Downloading source code..."
   download_source $install_type $version $source_path
 
   # Running this in a subshell because we don't to disturb the current
   # working directory.
   (
+    echo "Extracting source code..."
     cd $(dirname $source_path)
     tar -zxf $source_path || exit 1
 
@@ -80,12 +83,20 @@ install_php() {
     # target=$(get_target)
 
     # Build PHP
+    echo "Running buildconfig..."
     ./buildconf --force || exit 1
+    echo "Running ./configure $configure_options"
     ./configure $configure_options || exit 1
+    echo "Running make \"$make_flags\""
     make "$make_flags" || exit 1
+    echo "Running make install..."
     # make "$make_flags" test || exit 1
     make "$make_flags" install || exit 1
   )
+
+  # it's not obvious where php.ini should be placed, let us make it easy for the user
+  mkdir $install_path/conf.d/
+  echo "# add system-wide php configuration options here" > $install_path/conf.d/php.ini
 }
 
 install_composer() {
@@ -101,6 +112,8 @@ install_composer() {
 construct_configure_options() {
   local install_path=$1
 
+  # many options included below are not applicable to newer PHP versions
+  # including these will trigger a build warning, but will not b
   global_config="--prefix=$install_path \
     --enable-bcmath \
     --enable-calendar \
@@ -144,12 +157,6 @@ construct_configure_options() {
     local configure_options="$(os_based_configure_options) $global_config"
   else
     local configure_options="$PHP_CONFIGURE_OPTIONS $global_config"
-  fi
-
-  if [ "${PHP_WITH_GMP:-no}" != "no" ]; then
-    configure_options="$configure_options --with-gmp"
-  else
-    configure_options="$configure_options --without-gmp"
   fi
 
   if [ "${PHP_WITHOUT_PEAR:-no}" != "no" ]; then
@@ -208,8 +215,25 @@ os_based_configure_options() {
     local webp_path=$(homebrew_package_path webp)
     local zlib_path=$(homebrew_package_path zlib)
 
+    # optional
+    # if these packages exist they are included in the php compilation
+    local gmp_path=$(homebrew_package_path gmp)
+    local sodium_path=$(homebrew_package_path libsodium)
+
+    if [ -n "$gmp_path" ]; then
+      configure_options="--with-gmp=$gmp_path"
+    else
+      echo "gmp not found, not including in installation"
+    fi
+
+    if [ -n "$sodium_path" ]; then
+      configure_options="$configure_options --with-sodium=$sodium_path"
+    else
+      echo "sodium not found, not including in installation"
+    fi
+
     if [ -n "$freetype_path" ]; then
-      configure_options="--with-freetype-dir=$freetype_path"
+      configure_options="$configure_options --with-freetype-dir=$freetype_path"
     else
       export ASDF_PKG_MISSING="freetype"
     fi
@@ -366,4 +390,4 @@ get_php_version() {
 }
 
 install_php $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH
-install_composer $ASDF_INSTALL_PATH
+install_composer ${ASDF_INSTALL_PATH}


### PR DESCRIPTION
Quick overview:

* More status updates during installation
* Output ./configure options for easy debugging
* Support sodium and gmp extensions
* Lots of documentation updates

I removed `PHP_WITH_GMP` and autodetected the package instead. 