### PR TITLE
Remove unneeded note on `brew install`/`upgrade`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ extension=imagick.so" > $(asdf where php)/conf.d/php.ini
 
 To install PHP on macOS, you'll need a set of packages [installed via homebrew](https://github.com/asdf-community/asdf-php/blob/248e9c6e2a7824510788f05e8cee848a62200b65/.github/workflows/workflow.yml#L52).
 
-You may want to install these packages using `upgrade` instead of `install` to ensure the latest version of all required packages is installed.
-
 There's also a set of optional packages which enable additional extensions to be enabled:
 
 ```


### PR DESCRIPTION
Unless I'm missing something, `brew install` already upgrades if needed:

```
➜  ~ brew install gmp libsodium imagemagick
Warning: gmp 6.2.1 is already installed and up-to-date.
To reinstall 6.2.1, run:
  brew reinstall gmp
Warning: libsodium 1.0.18_1 is already installed and up-to-date.
To reinstall 1.0.18_1, run:
  brew reinstall libsodium
imagemagick 7.0.11-14 is installed but outdated
==> Upgrading imagemagick
  7.0.11-14 -> 7.1.0-0

[...]
```