### PR TITLE
Use OpenSSL 1.1 on macOS

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -49,32 +49,10 @@ jobs:
 
     steps:
       - name: Install packages
-        run: brew install autoconf automake bison freetype gd gettext icu4c krb5 libedit libiconv libjpeg libpng libxml2 libzip pkg-config re2c zlib
+        run: brew install autoconf automake bison freetype gd gettext icu4c krb5 libedit libiconv libjpeg libpng libxml2 libzip openssl@1.1 pkg-config re2c zlib
 
-      - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v1
-        with:
-          command: php --version
-          version: ${{ matrix.php-version }}
-
-  plugin-test-macos-openssl:
-    strategy:
-      matrix:
-        os:
-          - macos-latest
-        php-version:
-          - 7.4.14
-          - 8.0.0
-          - latest
-
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - name: Install packages
-        run: brew install autoconf automake bison freetype gd gettext icu4c krb5 libedit libiconv libjpeg libpng libxml2 libzip pkg-config re2c zlib
-
-      - name: Install OpenSSL casks
-        run: brew install openssl@1.1 openssl@3
+      - name: Install conflicting packages
+        run: brew install openssl@3
 
       - name: asdf_plugin_test
         uses: asdf-vm/actions/plugin-test@v1

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -57,6 +57,31 @@ jobs:
           command: php --version
           version: ${{ matrix.php-version }}
 
+  plugin-test-macos-openssl:
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+        php-version:
+          - 7.4.14
+          - 8.0.0
+          - latest
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Install packages
+        run: brew install autoconf automake bison freetype gd gettext icu4c krb5 libedit libiconv libjpeg libpng libxml2 libzip pkg-config re2c zlib
+
+      - name: Install OpenSSL casks
+        run: brew install openssl@1.1 openssl@3
+
+      - name: asdf_plugin_test
+        uses: asdf-vm/actions/plugin-test@v1
+        with:
+          command: php --version
+          version: ${{ matrix.php-version }}
+
   format:
     runs-on: ubuntu-latest
 

--- a/bin/install
+++ b/bin/install
@@ -28,7 +28,7 @@ install_php() {
     local krb5_path=$(homebrew_package_path krb5)
     local libedit_path=$(homebrew_package_path libedit)
     local libxml2_path=$(homebrew_package_path libxml2)
-    local openssl_path=$(homebrew_package_path openssl)
+    local openssl_path=$(homebrew_package_path openssl@1.1)
 
     if [ -n "$bison_path" ]; then
       export "PATH=${bison_path}/bin:${PATH}"
@@ -210,7 +210,7 @@ os_based_configure_options() {
     local libpng_path=$(homebrew_package_path libpng)
     local libxml2_path=$(homebrew_package_path libxml2)
     local libzip_path=$(homebrew_package_path libzip)
-    local openssl_path=$(homebrew_package_path openssl)
+    local openssl_path=$(homebrew_package_path openssl@1.1)
     local readline_path=$(homebrew_package_path readline)
     local webp_path=$(homebrew_package_path webp)
     local zlib_path=$(homebrew_package_path zlib)


### PR DESCRIPTION
Homebrew recently released `openssl@3`. This broke the plugin because it relies on `brew --prefix openssl` command to find OpenSSL. Introducing `openssl@3` changed the behavior of this command because now `openssl` points to `openssl@3`. PHP does not compile against this package. If the user did not previously `brew install openssl` (meaning `openssl@1.1` prior the introduction of `openssl@3`), then PHP would compile but the `composer` install would fail because `copy` could not support HTTPs. Sidebar: I assumed that the installer would pick up the macOS openssl but I guess not.

The solution to this problem is explicitly checking for `openssl@1.1` instead of `openssl`. I've updated the Github Actions workflow to include `openssl@3` to test that `asdf install php` work if this brew is installed.