### PR TITLE
Added php extensions required by magento 2

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -151,6 +151,8 @@ construct_configure_options() {
     --with-xmlrpc \
     --with-zip \
     --with-zlib \
+    --with-xsl \
+    --with-sodium \
     --without-snmp"
 
   if [ "$PHP_CONFIGURE_OPTIONS" = "" ]; then


### PR DESCRIPTION
Hi, I was able to install sodium afterwards manually using the pecl cli but I could not install xsl. The only solution I've found was to add it in the compilation. Is it ok to add them here? 