### PR TITLE
Fix PDO pgsql for macOS with Homebrew and disable PCRE JIT for M1

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -213,7 +213,7 @@ os_based_configure_options() {
 
     exit_if_homebrew_not_installed
 
-    if [[ `uname -m` == 'arm64' ]]; then
+    if [[ $(uname -m) == 'arm64' ]]; then
       configure_options="--without-pcre-jit"
     fi
 

--- a/bin/install
+++ b/bin/install
@@ -213,6 +213,10 @@ os_based_configure_options() {
 
     exit_if_homebrew_not_installed
 
+    if [[ `uname -m` == 'arm64' ]]; then
+      configure_options="--without-pcre-jit"
+    fi
+
     local bison_path=$(homebrew_package_path bison)
     local bzip2_path=$(homebrew_package_path bzip2)
     local freetype_path=$(homebrew_package_path freetype)
@@ -235,7 +239,7 @@ os_based_configure_options() {
     local sodium_path=$(homebrew_package_path libsodium)
 
     if [ -n "$gmp_path" ]; then
-      configure_options="--with-gmp=$gmp_path"
+      configure_options="$configure_options --with-gmp=$gmp_path"
     else
       echo "gmp not found, not including in installation"
     fi

--- a/bin/install
+++ b/bin/install
@@ -168,7 +168,21 @@ construct_configure_options() {
   if [ "${PHP_WITHOUT_PDO_PGSQL:-no}" != "no" ]; then
     configure_options="$configure_options"
   else
-    configure_options="$configure_options --with-pdo-pgsql"
+    local operating_system=$(uname -a)
+
+    if [[ $operating_system =~ "Darwin" ]]; then
+      exit_if_homebrew_not_installed
+
+      local libpq_path=$(homebrew_package_path libpq)
+
+      if [ -n "$libpq_path" ]; then
+        configure_options="$configure_options --with-pdo-pgsql=$libpq_path"
+      else
+        export ASDF_PKG_MISSING="$ASDF_PKG_MISSING libpq"
+      fi
+    else
+      configure_options="$configure_options --with-pdo-pgsql"
+    fi
   fi
 
   echo "$configure_options"


### PR DESCRIPTION
* Sets the `libpq` path configure option for macOS for PDO pgsql
* Disables PCRE JIT for arm64 (e.g. Apple M1) because it doesn't work (yet)

With these fixes we were able to install PHP 7.4, 8.0 and 8.1 on macOS with Intel (older 10.15) and Apple Silicon (12.2), so it should work for a wider variety of OS versions.