### PR TITLE
Update exec-env

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Set so that direnv and strict_env = true doesn't complain about unbound variable
+COMPOSER_HOME=${COMPOSER_HOME:-}
+
 # Set Composer's home directory if it's not set.
 if [ "$ASDF_INSTALL_VERSION" != "system" ]; then
   if [ -z "$COMPOSER_HOME" ]; then


### PR DESCRIPTION
Similar to the issue over on the ruby plugin (https://github.com/asdf-community/asdf-direnv/issues/115) if using direnv and have `strict_env = true` then it fails to load with `./exec-env:5: COMPOSER_HOME: unbound variable`