### PR TITLE
fix: enable XSL extension by default

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -144,6 +144,7 @@ construct_configure_options() {
     --with-fpm-group=www-data \
     --with-fpm-user=www-data \
     --with-gd \
+    --with-xsl \
     --with-mhash \
     --with-mysql=mysqlnd \
     --with-mysqli=mysqlnd \


### PR DESCRIPTION
This would be a nice addition, since playing around de XML/XSLT is often common, thank you!