### PR TITLE
install: add support for skipping composer install

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ asdf reshim
 php-cs-fixer --version
 ```
 
+You can skip installing composer by prefixing your install command with `PHP_INSTALL_COMPOSER=no`.
+
 ## License
 
 Licensed under the

--- a/bin/install
+++ b/bin/install
@@ -410,4 +410,6 @@ get_php_version() {
 }
 
 install_php "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"
-install_composer "$ASDF_INSTALL_PATH"
+if [ "${PHP_INSTALL_COMPOSER:-yes}" == "yes" ]; then
+  install_composer "$ASDF_INSTALL_PATH"
+fi


### PR DESCRIPTION
Allows folks to opt out of installing composer at install time.