### PR TITLE
Add PHP_ADDITIONAL_CONFIG_OPTIONS

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -191,6 +191,10 @@ construct_configure_options() {
     configure_options="$configure_options --without-pcre-jit"
   fi
 
+  if [ "${PHP_ADDITIONAL_CONFIG_OPTIONS" != "" ]; then
+    configure_options="$configure_options ${PHP_ADDITIONAL_CONFIG_OPTIONS}";
+  fi
+
   echo "$configure_options"
 }
 


### PR DESCRIPTION
Adding PHP_ADDITIONAL_CONFIG_OPTIONS to allow the user add custom build config options
to the script without changing default behavior.

Motivation: I had to mimic the build script to add a optional extension for
`password_hash(PASSWORD_ARGON2ID)` usage.

If I had this option I only needed to do `PHP_ADDITIONAL_CONFIG_OPTIONS="--with-password-argon2" asdf install php latest`
to add that option
