### PR TITLE
fix: PHP_WITHOUT_PCRE_JIT logic

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -186,8 +186,6 @@ construct_configure_options() {
   fi
 
   if [ "${PHP_WITHOUT_PCRE_JIT:-no}" != "no" ]; then
-    configure_options="$configure_options"
-  else
     configure_options="$configure_options --without-pcre-jit"
   fi
 


### PR DESCRIPTION
If `PHP_WITHOUT_PCRE_JIT` is not set (default value of `no`) or if it is explicitly set to `no`, then this means we want PCRE JIT support. The previous logic did the opposite.