### PR TITLE
make gmp flag configurable

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -159,6 +159,12 @@ construct_configure_options() {
     local configure_options="$PHP_CONFIGURE_OPTIONS $global_config"
   fi
 
+  if [ "${PHP_WITH_GMP:-no}" != "no" ]; then
+    configure_options="$configure_options --with-gmp"
+  else
+    configure_options="$configure_options --without-gmp"
+  fi
+
   if [ "${PHP_WITHOUT_PEAR:-no}" != "no" ]; then
     configure_options="$configure_options --without-pear"
   else


### PR DESCRIPTION
initially https://github.com/asdf-community/asdf-php/pull/68 PR added the ability to configure gmp but https://github.com/asdf-community/asdf-php/pull/82 PR removed it and make it automatic only for MacOS hence for non-MacOS it won't work and this PR aim to add it back