### PR TITLE
Install libgmp when compiling on Ubuntu

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -342,6 +342,7 @@ os_based_configure_options() {
   else
     local jpeg_path=$(locate libjpeg.so | awk '{ print length(), $0 | "sort -n" }' | cut -d" " -f2- | head -n 1)
     local libpng_path=$(locate libpng.so | awk '{ print length(), $0 | "sort -n" }' | cut -d" " -f2- | head -n 1)
+    local libgmp_path=$(locate libgmp.so | awk '{ print length(), $0 | "sort -n" }' | cut -d" " -f2- | head -n 1)
     configure_options="--with-openssl --with-curl --with-zlib --with-readline --with-gettext"
 
     if [ "$jpeg_path" = "" ]; then
@@ -354,6 +355,12 @@ os_based_configure_options() {
       export ASDF_PKG_MISSING="$ASDF_PKG_MISSING libpng"
     else
       configure_options="$configure_options --with-png-dir=$libpng_path --with-png"
+    fi
+
+    if [ "$libgmp_path" = "" ]; then
+      export ASDF_PKG_MISSING="$ASDF_PKG_MISSING libgmp"
+    else
+      configure_options="$configure_options --with-gmp-dir=$libgmp_path --with-gmp"
     fi
   fi
 


### PR DESCRIPTION
### Fixed

- The `gmp` extension wasn't being installed for me (on Ubuntu). This should fix it (already tested this approach locally)