### PR TITLE
fix: asdf >= v0.16.0 php install

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -16,7 +16,22 @@ install_php() {
   echo "Determining configuration options..."
   local source_path=$(get_download_file_path $install_type $version $tmp_download_dir)
   local configure_options="$(construct_configure_options $install_path)"
-  local make_flags="-j$ASDF_CONCURRENCY"
+
+  # Use a local variable for concurrency calculation
+  local_concurrency="${ASDF_CONCURRENCY}"
+  # If ASDF_CONCURRENCY is "auto" or not set, determine the number of CPU cores
+  if [[ "${local_concurrency:-auto}" == "auto" || -z "${local_concurrency}" ]]; then
+    if command -v nproc >/dev/null 2>&1; then
+      local_concurrency=$(nproc)
+    elif [[ "$(uname)" == "Darwin" ]]; then
+      local_concurrency=$(sysctl -n hw.ncpu)
+    else
+      local_concurrency=1 # Fallback if detection fails
+    fi
+  fi
+
+  # Now use the local_concurrency for make
+  make_flags="-j${local_concurrency}"
 
   local operating_system=$(uname -a)
 


### PR DESCRIPTION
**Description:**

From asdf version v0.16.0, this plugin breaks and fails when trying to install a PHP version. This PR introduces a fix that addresses this issue for asdf >= v0.16.0 while ensuring backward compatibility with older versions of asdf. Specifically, the default value of `ASDF_CONCURRENCY` as 'auto' breaks the PHP compiler.

Additionally, I recommend the maintainers set up the `bin/help.deps` script in the repository to define platform-specific dependencies, as detailed in the [asdf plugin documentation](https://asdf-vm.com/plugins/create.html#bin-help-deps). This will help list and check missing dependencies before attempting to compile new PHP versions.

Years ago, I faced a similar issue while building my own PHP version manager, which you can find here: [howiphp](https://github.com/mkungla/howiphp). I encountered the same challenge when listing and verifying missing dependencies prior to compiling PHP versions.

---

**Changes Introduced:**

- Fixes compatibility with asdf v0.16.0 and later versions.
- Ensures no breaking changes for versions prior to v0.16.0.

---

**Testing:**

- Tested with asdf v0.16.0 and v0.15.0 to verify proper functionality.
- Maintains compatibility with earlier versions of asdf.